### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,6 @@
+name        := "dnnl"
+description := "A performance and deep learning framework for neural networks optimized for Intel Architecture Processors and Intel Processor Graphics."
+gitrepo     := "https://github.com/intel/mkl-dnn.git"
+homepage    := "https://www.oneapi.io/open-source/"
+version     := 1.2 sha256:8f4e68b443ae87a0d97d968aed26e54e69c9612c69797c43965ea0dd0f0f7251 https://github.com/intel/mkl-dnn/archive/v1.2.zip
+license     := "Apache-2.0"


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

